### PR TITLE
docs: removed stray quotation mark in release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,7 @@ stabilization branches.
 Merging to `master` first also helps ensure that fixes applied to one release
 are present for future releases.  (Sometimes the joy of landing a critical
 release blocker in a branch causes you to forget to propagate back to
-`master`!)"
+`master`!)
 
 Once the bug fix lands on `master` it is cherry-picked into the `vX.Y` branch
 and potentially the `vX.Y-1` branch.  The exception to this rule is when a bug


### PR DESCRIPTION
Removed bad quotation mark at the end of sentence about propagating changes back to main branch.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
